### PR TITLE
Additional Tests and Inserting into FILE_OUTPUT_MOD_CONFIGS

### DIFF
--- a/dbs/datasets.go
+++ b/dbs/datasets.go
@@ -637,6 +637,7 @@ func (a *API) InsertDatasets() error {
 	if err != nil {
 		return Error(err, GetIDErrorCode, "", "dbs.datasets.InsertDatasets")
 	}
+	// match output_mod_config
 	for _, oc := range rec.OUTPUT_CONFIGS {
 		ocid, err := GetID(tx, "OUTPUT_MODULE_CONFIGS", "output_mod_config_id", "output_module_label", oc.OUTPUT_MODULE_LABEL)
 		if err != nil {
@@ -645,7 +646,7 @@ func (a *API) InsertDatasets() error {
 		r := DatasetOutputModConfigs{OUTPUT_MOD_CONFIG_ID: ocid, DATASET_ID: dsid}
 		err = r.Insert(tx)
 		if err != nil {
-			return Error(err, InsertErrorCode, "", "dbs.files.InsertFiles")
+			return Error(err, InsertErrorCode, "", "dbs.datasets.InsertDatasets")
 		}
 	}
 

--- a/dbs/dbs.go
+++ b/dbs/dbs.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"time"
 
-	validator "github.com/go-playground/validator/v10"
 	"github.com/dmwm/dbs2go/utils"
+	validator "github.com/go-playground/validator/v10"
 )
 
 // API structure represents DBS API. Each API has reader (to read

--- a/dbs/files.go
+++ b/dbs/files.go
@@ -561,6 +561,22 @@ func (a *API) InsertFiles() error {
 			}
 		}
 
+		// match output_mod_config
+		for _, oc := range rec.FILE_OUTPUT_CONFIG_LIST {
+			ocid, err := GetID(tx, "OUTPUT_MODULE_CONFIGS", "output_mod_config_id", "output_module_label", oc.OUTPUT_MODULE_LABEL)
+			if err != nil {
+				return Error(err, GetIDErrorCode, "", "dbs.files.InsertFiles")
+			}
+			r := FileOutputModConfigs{
+				OUTPUT_MOD_CONFIG_ID: ocid,
+				FILE_ID:              fid,
+			}
+			err = r.Insert(tx)
+			if err != nil {
+				return Error(err, InsertErrorCode, "", "dbs.files.InsertFiles")
+			}
+		}
+
 		// we need to update block info about inserted file
 		a.UpdateBlockStats(tx, blkId)
 

--- a/test/int_blocks.go
+++ b/test/int_blocks.go
@@ -157,3 +157,110 @@ func getBlocksTestTable(t *testing.T) EndpointTestCase {
 		},
 	}
 }
+
+// struct for block status update
+type blockUpdateStatusRequest struct {
+	BLOCK_NAME       string `json:"block_name"`
+	OPEN_FOR_WRITING string `json:"open_for_writing"`
+}
+
+// struct for block status update
+type blockUpdateSiteRequest struct {
+	BLOCK_NAME       string `json:"block_name"`
+	ORIGIN_SITE_NAME string `json:"origin_site_name"`
+}
+
+// detailed blocks API response
+func getBlocksTestTable2(t *testing.T) EndpointTestCase {
+	blkStatusReq := blockUpdateStatusRequest{
+		BLOCK_NAME:       TestData.Block,
+		OPEN_FOR_WRITING: "1",
+	}
+	blkSiteReq := blockUpdateSiteRequest{
+		BLOCK_NAME:       TestData.Block,
+		ORIGIN_SITE_NAME: "cmssrm2.fnal.gov",
+	}
+	blockDetailResp := blockDetailResponse{
+		BlockID:              1,
+		BlockName:            TestData.Block,
+		BlockSize:            20122119010,
+		CreateBy:             TestData.CreateBy,
+		CreationDate:         0,
+		Dataset:              TestData.Dataset,
+		DatasetID:            1,
+		FileCount:            10,
+		LastModificationDate: 0,
+		LastModifiedBy:       TestData.CreateBy,
+		OpenForWriting:       0,
+		OriginSiteName:       TestData.Site,
+	}
+	blockDetailResp2 := blockDetailResp
+	blockDetailResp2.OpenForWriting = 1
+	blockDetailResp2.LastModifiedBy = "DBS-workflow"
+	blockDetailResp3 := blockDetailResp2
+	blockDetailResp3.OriginSiteName = "cmssrm2.fnal.gov"
+	return EndpointTestCase{
+		description:     "Test blocks update API",
+		defaultEndpoint: "/dbs/blocks",
+		defaultHandler:  web.BlocksHandler,
+		testCases: []testCase{
+			{
+				description: "Initial GET block",
+				serverType:  "DBSReader",
+				method:      "GET",
+				params: url.Values{
+					"block_name": []string{TestData.Block},
+					"detail":     []string{"true"},
+				},
+				output:   []Response{blockDetailResp},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test update block status", // DBSClientWriter_t.test21
+				serverType:  "DBSWriter",
+				method:      "PUT",
+				params: url.Values{
+					"block_name":       []string{TestData.Block},
+					"open_for_writing": []string{"1"},
+				},
+				input:    blkStatusReq,
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "GET block after status update",
+				serverType:  "DBSReader",
+				method:      "GET",
+				params: url.Values{
+					"block_name": []string{TestData.Block},
+					"detail":     []string{"true"},
+				},
+				output:   []Response{blockDetailResp2},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test update block site name", // DBSClientWriter_t.test22
+				serverType:  "DBSWriter",
+				method:      "PUT",
+				params: url.Values{
+					"block_name":       []string{TestData.Block},
+					"origin_site_name": []string{"cmssrm2.fnal.gov"},
+				},
+				input:    blkSiteReq,
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "GET block after site update",
+				serverType:  "DBSReader",
+				method:      "GET",
+				params: url.Values{
+					"block_name": []string{TestData.Block},
+					"detail":     []string{"true"},
+				},
+				output:   []Response{blockDetailResp3},
+				respCode: http.StatusOK,
+			},
+		},
+	}
+}

--- a/test/int_files.go
+++ b/test/int_files.go
@@ -285,7 +285,7 @@ func getFilesTestTable2(t *testing.T) EndpointTestCase {
 		IS_FILE_VALID:     0,
 	}
 	return EndpointTestCase{
-		description:     "Test files 2",
+		description:     "Test files update",
 		defaultHandler:  web.FilesHandler,
 		defaultEndpoint: "/dbs/files",
 		testCases: []testCase{

--- a/test/int_files.go
+++ b/test/int_files.go
@@ -277,24 +277,77 @@ type filesPUTRequest struct {
 	IS_FILE_VALID     int64  `json:"is_file_valid" validate:"number"`
 }
 
-// files endpoint tests part 2
+// files endpoint update tests
 func getFilesTestTable2(t *testing.T) EndpointTestCase {
 	lfn := fmt.Sprintf("/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%v/%v.root", TestData.UID, 1)
 	fileReq := filesPUTRequest{
 		LOGICAL_FILE_NAME: lfn,
 		IS_FILE_VALID:     0,
 	}
+
+	fileResp := fileDetailResponse{
+		ADLER32:                "NOTSET",
+		AUTO_CROSS_SECTION:     0.0,
+		BLOCK_ID:               1,
+		BLOCK_NAME:             TestData.Block,
+		CHECK_SUM:              "1504266448",
+		CREATE_BY:              TestData.CreateBy,
+		CREATION_DATE:          0,
+		DATASET:                TestData.Dataset,
+		DATASET_ID:             1,
+		EventCount:             1619,
+		FILE_ID:                11,
+		FILE_SIZE:              2.012211901e+09,
+		FILE_TYPE:              "EDM",
+		FILE_TYPE_ID:           1,
+		IS_FILE_VALID:          1,
+		LAST_MODIFICATION_DATE: 0,
+		LAST_MODIFIED_BY:       TestData.CreateBy,
+		LOGICAL_FILE_NAME:      lfn,
+		MD5:                    "",
+	}
+
+	fileResp2 := fileResp
+	fileResp2.IS_FILE_VALID = 0
+	fileResp2.LAST_MODIFIED_BY = "DBS-workflow"
+
 	return EndpointTestCase{
 		description:     "Test files update",
 		defaultHandler:  web.FilesHandler,
 		defaultEndpoint: "/dbs/files",
 		testCases: []testCase{
 			{
+				description: "Test GET before update",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"logical_file_name": []string{lfn},
+					"detail":            []string{"true"},
+				},
+				output: []Response{
+					fileResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
 				description: "Test update file status",
 				method:      "PUT",
 				serverType:  "DBSWriter",
 				input:       fileReq,
 				respCode:    http.StatusOK,
+			},
+			{
+				description: "Test GET after update",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"logical_file_name": []string{lfn},
+					"detail":            []string{"true"},
+				},
+				output: []Response{
+					fileResp2,
+				},
+				respCode: http.StatusOK,
 			},
 		},
 	}

--- a/test/int_files.go
+++ b/test/int_files.go
@@ -137,14 +137,18 @@ func getFilesTestTable(t *testing.T) EndpointTestCase {
 	}
 	var parentFiles []dbs.FileRecord
 	var parentLFNs []Response
+	var testDataParentFiles []string
 	var parentDetailResp []Response
 	for i := 1; i <= 10; i++ {
 		parentLFN := fmt.Sprintf("/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/p%v/%v.root", TestData.UID, i)
 		parentLFNs = append(parentLFNs, fileResponse{LOGICAL_FILE_NAME: parentLFN})
+		testDataParentFiles = append(testDataParentFiles, parentLFN)
 		fileRecord := createFileRecord(i, TestData.ParentDataset, TestData.ParentBlock, parentFileLumiList, parentLFN, []dbs.FileParentLFNRecord{})
 		parentFiles = append(parentFiles, fileRecord)
 		parentDetailResp = append(parentDetailResp, createDetailedResponse(i, 2, 2, fileRecord))
 	}
+
+	TestData.ParentFiles = testDataParentFiles
 
 	fileLumiList := []dbs.FileLumi{
 		{LumiSectionNumber: 27414, RunNumber: 97},
@@ -155,9 +159,11 @@ func getFilesTestTable(t *testing.T) EndpointTestCase {
 	var files []dbs.FileRecord
 	var lfns []Response
 	var detailResp []Response
+	var testDataFiles []string
 	for i := 1; i <= 10; i++ {
 		lfn := fmt.Sprintf("/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/%v/%v.root", TestData.UID, i)
 		lfns = append(lfns, fileResponse{LOGICAL_FILE_NAME: lfn})
+		testDataFiles = append(testDataFiles, lfn)
 		fileParentLFN := fmt.Sprintf("/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/IDEAL_/p%v/%v.root", TestData.UID, i)
 		fileParentList := []dbs.FileParentLFNRecord{
 			{
@@ -168,6 +174,8 @@ func getFilesTestTable(t *testing.T) EndpointTestCase {
 		files = append(files, fileRecord)
 		detailResp = append(detailResp, createDetailedResponse(i+10, 1, 1, fileRecord))
 	}
+
+	TestData.Files = testDataFiles
 
 	// add run_num
 	var fileRunResp []Response

--- a/test/int_output_configs.go
+++ b/test/int_output_configs.go
@@ -7,6 +7,8 @@ package main
 
 import (
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/dmwm/dbs2go/dbs"
@@ -25,6 +27,18 @@ type outputConfigResponse struct {
 	CREATE_BY           string `json:"create_by"`
 }
 
+func createOutputConfigResponse(t *testing.T) outputConfigResponse {
+	return outputConfigResponse{
+		APP_NAME:            TestData.AppName,
+		RELEASE_VERSION:     TestData.ReleaseVersion,
+		PSET_HASH:           TestData.PsetHash,
+		GLOBAL_TAG:          TestData.GlobalTag,
+		OUTPUT_MODULE_LABEL: TestData.OutputModuleLabel,
+		CREATE_BY:           TestData.CreateBy,
+		CREATION_DATE:       0,
+	}
+}
+
 // outputconfigs endpoint tests
 // TODO: Rest of test cases
 func getOutputConfigTestTable(t *testing.T) EndpointTestCase {
@@ -37,15 +51,7 @@ func getOutputConfigTestTable(t *testing.T) EndpointTestCase {
 		CREATE_BY:           TestData.CreateBy,
 		SCENARIO:            "note",
 	}
-	outputConfigResp := outputConfigResponse{
-		APP_NAME:            TestData.AppName,
-		RELEASE_VERSION:     TestData.ReleaseVersion,
-		PSET_HASH:           TestData.PsetHash,
-		GLOBAL_TAG:          TestData.GlobalTag,
-		OUTPUT_MODULE_LABEL: TestData.OutputModuleLabel,
-		CREATE_BY:           TestData.CreateBy,
-		CREATION_DATE:       0,
-	}
+	outputConfigResp := createOutputConfigResponse(t)
 	return EndpointTestCase{
 		description:     "Test outputconfigs",
 		defaultHandler:  web.OutputConfigsHandler,
@@ -90,13 +96,213 @@ func getOutputConfigTestTable(t *testing.T) EndpointTestCase {
 				respCode:    http.StatusOK,
 			},
 			{
-				description: "Test GET after POST",
+				description: "Test GET after POST", // DBSClientReader_t.test017
 				method:      "GET",
 				serverType:  "DBSReader",
 				output: []Response{
 					outputConfigResp,
 				},
 				params:   nil,
+				respCode: http.StatusOK,
+			},
+		},
+	}
+}
+
+// outputconfigs endpoint test 2
+func getOutputConfigTestTable2(t *testing.T) EndpointTestCase {
+	outputConfigResp := createOutputConfigResponse(t)
+	splitLFN := strings.Split(TestData.Files[0], ".")
+	badLFN := splitLFN[0] + "abc" + splitLFN[1]
+	return EndpointTestCase{
+		description:     "Test outputconfigs 2",
+		defaultHandler:  web.OutputConfigsHandler,
+		defaultEndpoint: "/dbs/outputconfigs",
+		testCases: []testCase{
+			{
+				description: "Test GET using dataset", // DBSClientReader_t.test015
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing dataset",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset + "abc"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET using logical_file_name", // DBSClientReader_t.test016
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"logical_file_name": []string{TestData.Files[0]},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET using non-existing logical_file_name",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"logical_file_name": []string{badLFN},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET all", // DBSClientReader_t.test017
+				method:      "GET",
+				serverType:  "DBSReader",
+				params:      url.Values{},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with release_version", // DBSClientReader_t.test018
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"release_version": []string{TestData.ReleaseVersion},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing release_version",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"release_version": []string{TestData.ReleaseVersion + "3"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with pset_hash", // DBSClientReader_t.test019
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"pset_hash": []string{TestData.PsetHash},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing pset_hash",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"pset_hash": []string{TestData.PsetHash + "a"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with app_name", // DBSClientReader_t.test020
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"app_name": []string{TestData.AppName},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing app_name",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"app_name": []string{TestData.AppName + "a"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with output_module_label", // DBSClientReader_t.test021
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"output_module_label": []string{TestData.OutputModuleLabel},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing output_module_label",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"output_module_label": []string{TestData.OutputModuleLabel + "a"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with output_mod fields", // DBSClientReader_t.test022
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"release_version":     []string{TestData.ReleaseVersion},
+					"pset_hash":           []string{TestData.PsetHash},
+					"app_name":            []string{TestData.AppName},
+					"output_module_label": []string{TestData.OutputModuleLabel},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with dataset and output_mod fields", // DBSClientReader_t.test023
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset":             []string{TestData.Dataset},
+					"release_version":     []string{TestData.ReleaseVersion},
+					"pset_hash":           []string{TestData.PsetHash},
+					"app_name":            []string{TestData.AppName},
+					"output_module_label": []string{TestData.OutputModuleLabel},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with dataset and release_version", // DBSClientReader_t.test024
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset":         []string{TestData.Dataset},
+					"release_version": []string{TestData.ReleaseVersion},
+				},
+				output: []Response{
+					outputConfigResp,
+				},
 				respCode: http.StatusOK,
 			},
 		},

--- a/test/int_primary_datasets.go
+++ b/test/int_primary_datasets.go
@@ -131,7 +131,7 @@ func getPrimaryDatasetTestTable(t *testing.T) EndpointTestCase {
 				respCode: http.StatusOK,
 			},
 			{
-				description: "Test primarydatasets GET after POST",
+				description: "Test primarydatasets GET after POST", //DBSClientReader_t.test001
 				method:      "GET",
 				serverType:  "DBSReader",
 				output: []Response{
@@ -259,9 +259,47 @@ func getPrimaryDatasetTestTable(t *testing.T) EndpointTestCase {
 				respCode: http.StatusOK,
 			},
 			{
-				description: "Test primarydatasets GET after second POST",
+				description: "Test primarydatasets GET after second POST", // DBSClientReader_t.test001
 				method:      "GET",
 				serverType:  "DBSReader",
+				output: []Response{
+					primaryDSResp,
+					primaryDSResp2,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test primarydatasets GET param primary_ds_name=*", // DBSClientReader_t.test002
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"primary_ds_name": []string{"*"},
+				},
+				output: []Response{
+					primaryDSResp,
+					primaryDSResp2,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "primarydatasets GET param primary_ds_name defined", // DBSClientReader_t.test003
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"primary_ds_name": []string{TestData.PrimaryDSName},
+				},
+				output: []Response{
+					primaryDSResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "primarydatasets GET param primary_ds_name name with wildcard", // DBSClientReader_t.test004
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"primary_ds_name": []string{TestData.PrimaryDSName + "*"},
+				},
 				output: []Response{
 					primaryDSResp,
 					primaryDSResp2,

--- a/test/integration_cases.go
+++ b/test/integration_cases.go
@@ -226,6 +226,7 @@ func LoadTestCases(t *testing.T, filepath string) []EndpointTestCase {
 	filesUpdateTestCase := getFilesTestTable2(t)
 	datasetsUpdateTestCase := getDatasetsTestTable3(t)
 	blockUpdateTestCase := getBlocksTestTable2(t)
+	outputConfigTestCase2 := getOutputConfigTestTable2(t)
 
 	return []EndpointTestCase{
 		primaryDatasetAndTypesTestCase,
@@ -242,5 +243,6 @@ func LoadTestCases(t *testing.T, filepath string) []EndpointTestCase {
 		filesUpdateTestCase,
 		datasetsUpdateTestCase,
 		blockUpdateTestCase,
+		outputConfigTestCase2,
 	}
 }

--- a/test/integration_cases.go
+++ b/test/integration_cases.go
@@ -223,8 +223,9 @@ func LoadTestCases(t *testing.T, filepath string) []EndpointTestCase {
 	blocksTestCase := getBlocksTestTable(t)
 	filesTestCase := getFilesTestTable(t)
 	datasetsTestCase2 := getDatasetsTestTable2(t)
-	filesTestCase2 := getFilesTestTable2(t)
-	datasetsTestCase3 := getDatasetsTestTable3(t)
+	filesUpdateTestCase := getFilesTestTable2(t)
+	datasetsUpdateTestCase := getDatasetsTestTable3(t)
+	blockUpdateTestCase := getBlocksTestTable2(t)
 
 	return []EndpointTestCase{
 		primaryDatasetAndTypesTestCase,
@@ -238,7 +239,8 @@ func LoadTestCases(t *testing.T, filepath string) []EndpointTestCase {
 		blocksTestCase,
 		filesTestCase,
 		datasetsTestCase2,
-		filesTestCase2,
-		datasetsTestCase3,
+		filesUpdateTestCase,
+		datasetsUpdateTestCase,
+		blockUpdateTestCase,
 	}
 }


### PR DESCRIPTION
Includes `/blocks` API update tests, `/files` update tests, and additional tests from DBSClient.

Also adds functionality to `/files` API in which OUTPUT_MOD_CONFIGS are read. The commit message for this one (02b51deec336348269873e733fb949abc160771b) is incorrect.