### PR TITLE
Blocks GET API Query Parameter Check

### DIFF
--- a/dbs/blocks.go
+++ b/dbs/blocks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +23,21 @@ func (a *API) Blocks() error {
 	tmpl["Owner"] = DBOWNER
 	tmpl["TokenGenerator"] = ""
 	tmpl["Detail"] = false
+
+	// check for required parameters
+	required := []string{
+		"dataset",
+		"block_name",
+		"data_tier_name",
+		"logical_file_name",
+	}
+	pattern := strings.Join(required, "|")
+	re := regexp.MustCompile(pattern)
+	match := re.MatchString(fmt.Sprintf("%v", a.Params))
+	if !match {
+		msg := fmt.Sprintf("Blocks API requires one of the following: %v", required)
+		return Error(InvalidParamErr, ParametersErrorCode, msg, "dbs.blocks.Blocks")
+	}
 
 	// parse detail argument
 	detail, _ := getSingleValue(a.Params, "detail")

--- a/test/int_blocks.go
+++ b/test/int_blocks.go
@@ -7,8 +7,10 @@ package main
 // the HTTP handlers and endpoints are defined in the EndpointTestCase struct defined in test/integration_cases.go
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/dmwm/dbs2go/dbs"
@@ -84,6 +86,26 @@ func getBlocksTestTable(t *testing.T) EndpointTestCase {
 		OpenForWriting:       0,
 		OriginSiteName:       TestData.Site,
 	}
+	dbsError := dbs.DBSError{
+		Function: "dbs.blocks.Blocks",
+		Code:     dbs.ParametersErrorCode,
+		Reason:   dbs.InvalidParamErr.Error(),
+		Message:  "Blocks API requires one of the following: [dataset block_name data_tier_name logical_file_name]",
+	}
+	hrec := web.HTTPError{
+		Method:    "GET",
+		Timestamp: "",
+		HTTPCode:  http.StatusBadRequest,
+		Path:      "/dbs/blocks?origin_site_name=cmssrm.fnal.gov",
+		UserAgent: "Go-http-client/1.1",
+	}
+	errorResp := web.ServerError{
+		HTTPError: hrec,
+		DBSError:  &dbsError,
+		Exception: http.StatusBadRequest,
+		Type:      "HTTPError",
+		Message:   dbsError.Error(),
+	}
 	return EndpointTestCase{
 		description:     "Test blocks",
 		defaultHandler:  web.BlocksHandler,
@@ -94,22 +116,30 @@ func getBlocksTestTable(t *testing.T) EndpointTestCase {
 				method:      "GET",
 				serverType:  "DBSReader",
 				input:       nil,
-				params:      nil,
-				output:      []Response{},
-				respCode:    http.StatusOK,
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
 			},
 			{
 				description: "Test POST",
 				method:      "POST",
 				serverType:  "DBSWriter",
 				input:       blockReq,
-				output:      []Response{},
-				respCode:    http.StatusOK,
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
 			},
 			{
 				description: "Test GET after POST",
 				method:      "GET",
 				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
 				output: []Response{
 					blockResp,
 				},
@@ -120,21 +150,30 @@ func getBlocksTestTable(t *testing.T) EndpointTestCase {
 				method:      "POST",
 				serverType:  "DBSWriter",
 				input:       parentBlockReq,
-				output:      []Response{},
-				respCode:    http.StatusOK,
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
 			},
 			{
 				description: "Test duplicate POST",
 				method:      "POST",
 				serverType:  "DBSWriter",
 				input:       blockReq,
-				output:      []Response{},
-				respCode:    http.StatusOK,
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
 			},
 			{
 				description: "Test GET after POST",
 				method:      "GET",
 				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset, TestData.ParentDataset},
+				},
 				output: []Response{
 					blockResp,
 					blockParentResp,
@@ -146,13 +185,110 @@ func getBlocksTestTable(t *testing.T) EndpointTestCase {
 				method:      "GET",
 				serverType:  "DBSReader",
 				params: url.Values{
-					"detail": []string{"true"},
+					"dataset": []string{TestData.Dataset, TestData.ParentDataset},
+					"detail":  []string{"true"},
 				},
 				output: []Response{
 					blockDetailResp,
 					blockParentDetailResp,
 				},
 				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with block", // DBSClientReader_t.test025
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"block_name": []string{TestData.Block},
+				},
+				output: []Response{
+					blockResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing block",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"block_name": []string{TestData.Block + "1"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with dataset", // DBSClientReader_t.test026
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+				},
+				output: []Response{
+					blockResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with non-existing dataset",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset + "1"},
+				},
+				output:   []Response{},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with block and origin_site_name", // DBSClientReader_t.test027
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"block_name":       []string{TestData.Block},
+					"origin_site_name": []string{TestData.Site},
+				},
+				output: []Response{
+					blockResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with dataset and origin_site_name", // DBSClientReader_t.test028
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset":          []string{TestData.Dataset},
+					"origin_site_name": []string{TestData.Site},
+				},
+				output: []Response{
+					blockResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with dataset block and origin_site_name", // DBSClientReader_t.test029a
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset":          []string{TestData.Dataset},
+					"block":            []string{TestData.Block},
+					"origin_site_name": []string{TestData.Site},
+				},
+				output: []Response{
+					blockResp,
+				},
+				respCode: http.StatusOK,
+			},
+			{
+				description: "Test GET with only origin_site_name", // DBSClientReader_t.test029a1
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"origin_site_name": []string{TestData.Site},
+				},
+				output: []Response{
+					errorResp,
+				},
+				respCode: http.StatusBadRequest,
 			},
 		},
 	}
@@ -168,6 +304,42 @@ type blockUpdateStatusRequest struct {
 type blockUpdateSiteRequest struct {
 	BLOCK_NAME       string `json:"block_name"`
 	ORIGIN_SITE_NAME string `json:"origin_site_name"`
+}
+
+// detailed blocks API response
+type blockRunDetailResponse struct {
+	BlockID              int64  `json:"block_id"`
+	DatasetID            int64  `json:"dataset_id"`
+	CreateBy             string `json:"create_by"`
+	CreationDate         int64  `json:"creation_date"`
+	Dataset              string `json:"dataset"`
+	OpenForWriting       int64  `json:"open_for_writing"`
+	BlockName            string `json:"block_name"`
+	FileCount            int64  `json:"file_count"`
+	OriginSiteName       string `json:"origin_site_name"`
+	BlockSize            int64  `json:"block_size"`
+	LastModifiedBy       string `json:"last_modified_by"`
+	LastModificationDate int64  `json:"last_modification_date"`
+	RunNum               int64  `json:"run_num"`
+}
+
+// create a detailed response with run_num
+func createBlockRunDetailResponse(blockID int64, runNum int) blockRunDetailResponse {
+	return blockRunDetailResponse{
+		BlockID:              blockID,
+		BlockName:            TestData.Block,
+		BlockSize:            20122119010,
+		CreateBy:             TestData.CreateBy,
+		CreationDate:         0,
+		Dataset:              TestData.Dataset,
+		DatasetID:            1,
+		FileCount:            10,
+		LastModificationDate: 0,
+		LastModifiedBy:       TestData.CreateBy,
+		OpenForWriting:       0,
+		OriginSiteName:       TestData.Site,
+		RunNum:               int64(runNum),
+	}
 }
 
 // detailed blocks API response
@@ -199,11 +371,29 @@ func getBlocksTestTable2(t *testing.T) EndpointTestCase {
 	blockDetailResp2.LastModifiedBy = "DBS-workflow"
 	blockDetailResp3 := blockDetailResp2
 	blockDetailResp3.OriginSiteName = "cmssrm2.fnal.gov"
+
+	runs := strings.ReplaceAll(fmt.Sprint(TestData.Runs), " ", ",")
+	var blockRunDetailResp []Response
+	for _, run := range TestData.Runs {
+		blockRunDetailResp = append(blockRunDetailResp, createBlockRunDetailResponse(1, run))
+	}
 	return EndpointTestCase{
 		description:     "Test blocks update API",
 		defaultEndpoint: "/dbs/blocks",
 		defaultHandler:  web.BlocksHandler,
 		testCases: []testCase{
+			{
+				description: "Test GET with dataset, run_num, detail", // DBSClientReader_t.test029b
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"dataset": []string{TestData.Dataset},
+					"run_num": []string{runs},
+					"detail":  []string{"true"},
+				},
+				output:   blockRunDetailResp,
+				respCode: http.StatusOK,
+			},
 			{
 				description: "Initial GET block",
 				serverType:  "DBSReader",

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -60,8 +60,9 @@ func runTestWorkflow(t *testing.T, c EndpointTestCase) {
 
 				// Set headers
 				headers := http.Header{
-					"Accept":       []string{"application/json"},
-					"Content-Type": []string{"application/json"},
+					"Accept":          []string{"application/json"},
+					"Content-Type":    []string{"application/json"},
+					"Accept-Encoding": []string{"identity"},
 				}
 				req := newreq(t, v.method, server.URL, endpoint, reader, v.params, headers)
 

--- a/test/main.go
+++ b/test/main.go
@@ -198,7 +198,7 @@ func verifyResponse(t *testing.T, received []dbs.Record, expected []Response) {
 			} else if utils.InList(field, ignoredFields) {
 				continue
 			} else {
-				t.Fatalf("Incorrect %v, received %v (%T), expected %v (%T)", field, a.To, a.To, a.From, a.From)
+				t.Fatalf("Incorrect %v:\nreceived %v (%T),\nexpected %v (%T)", field, a.To, a.To, a.From, a.From)
 			}
 		}
 	}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -646,8 +646,6 @@ func DBSGetHandler(w http.ResponseWriter, r *http.Request, a string) {
 		err = api.FileSummaries()
 	} else if a == "filelumis" {
 		err = api.FileLumis()
-	} else if a == "primarydstypes" {
-		err = api.PrimaryDSTypes()
 	} else if a == "datasetparents" {
 		err = api.DatasetParents()
 	} else if a == "datatypes" {


### PR DESCRIPTION
While doing a blocks GET test, test29a1 in DBSClientReader_t shows that without providing one of the four required query parameters (`dataset`,	`block_name`,`data_tier_name`,`logical_file_name`), the server should respond with HTTP 400. This was added to this server.

Original Test:
https://github.com/dmwm/DBSClient/blob/0037373af2c7df509438d455bae60796b25bbcd5/tests/dbsclient_t/unittests/DBSClientReader_t.py#L278-L281

DBS logic:
https://github.com/dmwm/DBS/blob/14df8bbe8ee8f874fe423399b18afef911fe78c7/Server/Python/src/dbs/business/DBSBlock.py#L233-L245