### PR TITLE
Large run-lumis insert integration tests for Issue #46

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ test-integration:
 	DBS_DB_FILE=./dbfile \
 	INTEGRATION_DATA_FILE=./data/integration/integration_data.json \
 	BULKBLOCKS_DATA_FILE=./data/integration/bulkblocks_data.json \
+	LARGE_BULKBLOCKS_DATA_FILE=./data/integration/largebulkblocks_data.json \
+	FILE_LUMI_LIST_LENGTH=30 \
 	go test -v -failfast -run Integration
 test-migration:
 	cd test && rm -f /tmp/dbs-one.db && \

--- a/test/data/integration/largebulkblocks_data.json
+++ b/test/data/integration/largebulkblocks_data.json
@@ -1,0 +1,246 @@
+{
+ "dataset_conf_list": [
+  {
+   "release_version": "CMSSW_1_2_3",
+   "pset_hash": "76e303993a1c2f842159dbfeeed9a0dd",
+   "pset_name": "",
+   "app_name": "cmsRun",
+   "output_module_label": "merged",
+   "global_tag": "my-cms-gtag_8268",
+   "create_by": "",
+   "creation_date": 0
+  }
+ ],
+ "file_conf_list": [
+  {
+   "release_version": "CMSSW_1_2_3",
+   "pset_hash": "76e303993a1c2f842159dbfeeed9a0dd",
+   "pset_name": "",
+   "lfn": "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/StepChain10_/p8268/1.root",
+   "app_name": "cmsRun",
+   "output_module_label": "merged",
+   "global_tag": "my-cms-gtag_8268",
+   "create_by": "",
+   "creation_date": 0
+  }
+ ],
+ "files": [
+  {
+   "check_sum": "1504266448",
+   "file_lumi_list": [
+    {
+     "lumi_section_num": 22800,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22801,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22802,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22803,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22804,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22805,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22806,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22807,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22808,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22809,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22810,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22811,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22812,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22813,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22814,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22815,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22816,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22817,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22818,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22819,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22820,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22821,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22822,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22823,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22824,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22825,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22826,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22827,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22828,
+     "run_num": 100,
+     "event_count": 70
+    },
+    {
+     "lumi_section_num": 22829,
+     "run_num": 100,
+     "event_count": 70
+    }
+   ],
+   "adler32": "NOTSET",
+   "file_size": 2012211901,
+   "event_count": 201,
+   "file_type": "EDM",
+   "last_modified_by": "",
+   "last_modification_date": 0,
+   "logical_file_name": "/store/mc/Fall08/BBJets250to500-madgraph/GEN-SIM-RAW/StepChain10_/p8268/1.root",
+   "md5": "",
+   "auto_cross_section": 0,
+   "is_file_valid": 1
+  }
+ ],
+ "processing_era": {
+  "create_by": "WMAgent",
+  "creation_date": 0,
+  "processing_version": 8268,
+  "description": ""
+ },
+ "primds": {
+  "primary_ds_id": 0,
+  "create_by": "WMAgent",
+  "primary_ds_type": "test",
+  "primary_ds_name": "unittest_web_primary_ds_name_8268_stepchain3",
+  "creation_date": 1654135395
+ },
+ "dataset": {
+  "dataset_id": 0,
+  "create_by": "WMAgent",
+  "creation_date": 1654135395,
+  "physics_group_name": "Tracker",
+  "dataset_access_type": "PRODUCTION",
+  "data_tier_name": "GEN-SIM-RAW",
+  "last_modified_by": "WMAgent",
+  "processed_ds_name": "acq_era_8268-ptsr-v82683",
+  "xtcrosssection": 0,
+  "last_modification_date": 1654135395,
+  "dataset": "/unittest_web_primary_ds_name_8268_stepchain/acq_era_8268-ptsr-v8268/GEN-SIM-RAW3",
+  "prep_id": "TestPrepID"
+ },
+ "acquisition_era": {
+  "acquisition_era_name": "acq_era_8268",
+  "start_date": 123456789,
+  "creation_date": 0,
+  "end_date": 0,
+  "create_by": "",
+  "description": ""
+ },
+ "block": {
+  "block_id": 0,
+  "dataset_id": 0,
+  "create_by": "",
+  "creation_date": 0,
+  "open_for_writing": 0,
+  "block_name": "/unittest_web_primary_ds_name_8268_stepchain/acq_era_8268-ptsr-v8268/GEN-SIM-RAW#82683",
+  "file_count": 30,
+  "origin_site_name": "cmssrm.fnal.gov",
+  "block_size": 20122119010,
+  "last_modified_by": "",
+  "last_modification_date": 0
+ },
+ "file_parent_list": null,
+ "block_parent_list": null,
+ "dataset_parent_list": [],
+ "ds_parent_list": null
+}

--- a/test/int_bulkblocks.go
+++ b/test/int_bulkblocks.go
@@ -79,3 +79,28 @@ func getBulkBlocksTestTable(t *testing.T) EndpointTestCase {
 		},
 	}
 }
+
+// bulkblocks test table
+func getBulkBlocksLargeFileLumiInsertTestTable(t *testing.T) EndpointTestCase {
+	return EndpointTestCase{
+		description:     "Test concurrent bulkblocks when fileLumiChunkSize less than number fileLumis inserted",
+		defaultHandler:  web.BulkBlocksHandler,
+		defaultEndpoint: "/dbs/bulkblocks",
+		testCases: []testCase{
+			{
+				description:          "Test POST with fileLumiChunk size 20",
+				serverType:           "DBSWriter",
+				method:               "POST",
+				fileLumiChunkSize:    20,
+				concurrentBulkBlocks: true,
+				input:                LargeBulkBlocksData,
+				params: url.Values{
+					"block_name": []string{TestData.StepchainBlock + "2"},
+				},
+				output:   []Response{},
+				handler:  web.FilesHandler,
+				respCode: http.StatusOK,
+			},
+		},
+	}
+}

--- a/test/int_filearray.go
+++ b/test/int_filearray.go
@@ -188,6 +188,47 @@ type fileArrayLFNRunNumSumOverLumiDetailRequest struct {
 	Detail          string `json:"detail"`
 }
 
+// fileArray request with dataset, release_version
+type fileArrayDatasetReleaseRequest struct {
+	Dataset        string `json:"dataset"`
+	ReleaseVersion string `json:"release_version"`
+}
+
+// fileArray request with dataset, release_version, validFileOnly
+type fileArrayDatasetReleaseValidFileRequest struct {
+	Dataset        string `json:"dataset"`
+	ReleaseVersion string `json:"release_version"`
+	ValidFileOnly  string `json:"validFileOnly"`
+}
+
+// fileArray request with dataset, output_module_config fields
+type fileArrayDatasetOutputModRequest struct {
+	Dataset           string `json:"dataset"`
+	ReleaseVersion    string `json:"release_version"`
+	PsetHash          string `json:"pset_hash"`
+	AppName           string `json:"app_name"`
+	OutputModuleLabel string `json:"output_module_label"`
+}
+
+// fileArray request with lfn, output_module_config fields
+type fileArrayLFNOutputModRequest struct {
+	LogicalFileName   string `json:"logical_file_name"`
+	ReleaseVersion    string `json:"release_version"`
+	PsetHash          string `json:"pset_hash"`
+	AppName           string `json:"app_name"`
+	OutputModuleLabel string `json:"output_module_label"`
+}
+
+// fileArray request with lfn, output_module_config fields, validFileOnly
+type fileArrayLFNOutputModValidFileRequest struct {
+	LogicalFileName   string `json:"logical_file_name"`
+	ReleaseVersion    string `json:"release_version"`
+	PsetHash          string `json:"pset_hash"`
+	AppName           string `json:"app_name"`
+	OutputModuleLabel string `json:"output_module_label"`
+	ValidFileOnly     string `json:"validFileOnly"`
+}
+
 // test fileArray
 func getFileArrayTestTable(t *testing.T) []EndpointTestCase {
 	fileLumiList := []dbs.FileLumi{
@@ -799,6 +840,123 @@ func getFileArrayTestTable(t *testing.T) []EndpointTestCase {
 						Detail:          "1",
 					},
 					output:   detailRunSumLumiResp,
+					respCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			description:     "Test fileArray with dataset and output_module_config parameters",
+			defaultHandler:  web.FileArrayHandler,
+			defaultEndpoint: "/dbs/fileArray",
+			testCases: []testCase{
+				{
+					description: "Test POST with dataset and release_version", // DBSClientReader_t.test03500a
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayDatasetReleaseRequest{
+						Dataset:        TestData.Dataset,
+						ReleaseVersion: TestData.ReleaseVersion,
+					},
+					output:   lfns,
+					respCode: http.StatusOK,
+				},
+				{
+					description: "Test POST with dataset, release_version, validFileOnly 1", // DBSClientReader_t.test03500b
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayDatasetReleaseValidFileRequest{
+						Dataset:        TestData.Dataset,
+						ReleaseVersion: TestData.ReleaseVersion,
+						ValidFileOnly:  "1",
+					},
+					output:   lfns[1:],
+					respCode: http.StatusOK,
+				},
+				{
+					description: "Test POST with dataset, release_version, pset_hash, app_name, output_module_label", // DBSClientReader_t.test03600
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayDatasetOutputModRequest{
+						Dataset:           TestData.Dataset,
+						ReleaseVersion:    TestData.ReleaseVersion,
+						PsetHash:          TestData.PsetHash,
+						AppName:           TestData.AppName,
+						OutputModuleLabel: TestData.OutputModuleLabel,
+					},
+					output:   lfns,
+					respCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			description:     "Test fileArray with logical_file_name and output_module_config parameters",
+			defaultHandler:  web.FileArrayHandler,
+			defaultEndpoint: "/dbs/fileArray",
+			testCases: []testCase{
+				{
+					description: "Test POST with dataset and release_version", // DBSClientReader_t.test03700a
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayLFNOutputModRequest{
+						LogicalFileName:   TestData.Files[0],
+						ReleaseVersion:    TestData.ReleaseVersion,
+						PsetHash:          TestData.PsetHash,
+						AppName:           TestData.AppName,
+						OutputModuleLabel: TestData.OutputModuleLabel,
+					},
+					output:   lfns[:1],
+					respCode: http.StatusOK,
+				},
+				{
+					description: "Test POST with dataset, release_version, pset_hash, app_name, output_module_label", // DBSClientReader_t.test03700b
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayLFNOutputModValidFileRequest{
+						LogicalFileName:   TestData.Files[1],
+						ReleaseVersion:    TestData.ReleaseVersion,
+						PsetHash:          TestData.PsetHash,
+						AppName:           TestData.AppName,
+						OutputModuleLabel: TestData.OutputModuleLabel,
+						ValidFileOnly:     "1",
+					},
+					output:   lfns[1:2],
+					respCode: http.StatusOK,
+				},
+			},
+		},
+		{
+			description:     "Test fileArray with non-existing fields",
+			defaultHandler:  web.FileArrayHandler,
+			defaultEndpoint: "/dbs/fileArray",
+			testCases: []testCase{
+				{
+					description: "Test POST with non-existing dataset", // DBSClientReader_t.test03800
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayDatasetRequest{
+						Dataset: "/does/not/EXIST",
+					},
+					output:   []Response{},
+					respCode: http.StatusOK,
+				},
+				{
+					description: "Test POST with non-existing block_name", // DBSClientReader_t.test03900
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayBlockNameRequest{
+						BlockName: "/does/not/EXIST#123",
+					},
+					output:   []Response{},
+					respCode: http.StatusOK,
+				},
+				{
+					description: "Test POST with non-existing logical_file_name", // DBSClientReader_t.test0400
+					method:      "POST",
+					serverType:  "DBSReader",
+					input: fileArrayLFNRequest{
+						LogicalFileName: "/store/mc/does/not/EXIST/NotReally/0815/doesnotexist.root",
+					},
+					output:   []Response{},
 					respCode: http.StatusOK,
 				},
 			},

--- a/test/int_filelumis.go
+++ b/test/int_filelumis.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/dmwm/dbs2go/web"
+)
+
+// this file contains logic for fileLumi API
+// the basic HTTP response body is defined by fileLumiResponse struct in this file
+// the HTTP handlers and endpoints are defined in the EndpointTestCase struct defined in test/integration_cases.go
+
+// fileLumi response
+type fileLumiResponse struct {
+	EventCount      int    `json:"event_count"`
+	LogicalFileName string `json:"logical_file_name"`
+	LumiSectionNum  int    `json:"lumi_section_num"`
+	RunNum          int    `json:"run_num"`
+}
+
+// fileLumi chunk test table
+func getFileLumiChunkTestTable(t *testing.T) EndpointTestCase {
+	var fileLumiResp []Response
+	for _, v := range LargeBulkBlocksData.Files {
+		for _, fl := range v.FileLumiList {
+			flr := fileLumiResponse{
+				EventCount:      int(fl.EventCount),
+				LogicalFileName: v.LogicalFileName,
+				LumiSectionNum:  int(fl.LumiSectionNumber),
+				RunNum:          int(fl.RunNumber),
+			}
+			fileLumiResp = append(fileLumiResp, flr)
+		}
+	}
+	return EndpointTestCase{
+		description:     "Test files GET after file lumi chunk insert",
+		defaultHandler:  web.FilesHandler,
+		defaultEndpoint: "/dbs/filelumis",
+		testCases: []testCase{
+			{
+				description: "Test files GET after fileLumiChunk exceed",
+				method:      "GET",
+				serverType:  "DBSReader",
+				params: url.Values{
+					"block_name": []string{LargeBulkBlocksData.Block.BlockName},
+				},
+				output:   fileLumiResp,
+				respCode: http.StatusOK,
+			},
+		},
+	}
+}

--- a/test/main.go
+++ b/test/main.go
@@ -104,7 +104,7 @@ func newreq(t *testing.T, method string, hostname string, endpoint string, body 
 }
 
 // helper funtion to return DBS server with basic parameters
-func dbsServer(t *testing.T, base, dbFile, serverType string, concurrent bool) *httptest.Server {
+func dbsServer(t *testing.T, base, dbFile, serverType string, concurrent bool, flChunkSize int) *httptest.Server {
 	dbfile := os.Getenv(dbFile)
 	if dbfile == "" {
 		log.Fatalf("no %s env variable, please define", dbFile)
@@ -139,6 +139,7 @@ func dbsServer(t *testing.T, base, dbFile, serverType string, concurrent bool) *
 	web.Config.LogFile = fmt.Sprintf("/tmp/dbs2go-%s.log", base)
 	web.Config.Verbose = 0
 	web.Config.ConcurrentBulkBlocks = concurrent
+	web.Config.FileLumiChunkSize = flChunkSize
 	utils.VERBOSE = 0
 	utils.BASE = base
 	lexPatterns, err := dbs.LoadPatterns(lexiconFile)

--- a/test/migration_test.go
+++ b/test/migration_test.go
@@ -29,32 +29,32 @@ func TestMigration(t *testing.T) {
 
 	// start DBSReader server from which we will read the data for migration process
 	base := "dbs-one-reader"
-	srv1 := dbsServer(t, base, "DBS_DB_FILE_1", "DBSReader", false)
+	srv1 := dbsServer(t, base, "DBS_DB_FILE_1", "DBSReader", false, 500)
 	checkServer(t, srv1.URL, base)
 
 	// start DBSWriter server to which we will write the data
 	base = "dbs-one-writer"
-	srv2 := dbsServer(t, base, "DBS_DB_FILE_1", "DBSWriter", false)
+	srv2 := dbsServer(t, base, "DBS_DB_FILE_1", "DBSWriter", false, 500)
 	checkServer(t, srv2.URL, base)
 
 	// start DBSReader server from which we will read the data after migration process
 	base = "dbs-two-reader"
-	srv3 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSReader", false)
+	srv3 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSReader", false, 500)
 	checkServer(t, srv3.URL, base)
 
 	// start DBSWriter server to which we will write the data durign migration process
 	base = "dbs-two-writer"
-	srv4 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSWriter", false)
+	srv4 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSWriter", false, 500)
 	checkServer(t, srv4.URL, base)
 
 	// start DBSMigrate server to which we will post migration requests
 	base = "dbs-migrate"
-	srv5 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSMigrate", false)
+	srv5 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSMigrate", false, 500)
 	checkServer(t, srv5.URL, base)
 
 	// start DBSMigration server which will process migration requests
 	base = "dbs-migration"
-	srv6 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSMigration", false)
+	srv6 := dbsServer(t, base, "DBS_DB_FILE_2", "DBSMigration", false, 500)
 	checkServer(t, srv6.URL, base)
 }
 


### PR DESCRIPTION
Addressing Issue #46 

Generates run-lumis for a concurrent bulkblocks insert depending on environment variable FILE_LUMI_LIST_LENGTH
Stores the generated data into location defined by LARGE_BULKBLOCKS_DATA_FILE

Will regenerate if the length of run-lumis in the LARGE_BULKBLOCKS_DATA_FILE differs from FILE_LUMI_LIST_LENGTH

Does an initial test for when server FileLumiChunkSize is 20, while FILE_LUMI_LIST_LENGTH is 30.