### PR TITLE
add warning comment

### DIFF
--- a/dbs/migrate.go
+++ b/dbs/migrate.go
@@ -578,6 +578,7 @@ func alreadyQueued(input string) error {
 		return err
 	}
 	if mid != 0 {
+		// ATTENTION! Changing following string will break CRAB Publisher
 		msg := fmt.Sprintf("migration request %s is already exist in DB with id=%d", input, mid)
 		return errors.New(msg)
 	}


### PR DESCRIPTION
text of reason string for migration alreadyQueued is looked for in CRAB Pubisher. Do not change w/o careful coordination, and only if absolutely needed.

I did not/can not test. Hopefully I have used correct syntax for comment. In case feel free to change