### PR TITLE
Fix error code when parent file is not found

### DIFF
--- a/dbs/bulkblocks2.go
+++ b/dbs/bulkblocks2.go
@@ -505,7 +505,7 @@ func (a *API) InsertBulkBlocksConcurrently() error {
 		pfid, err := QueryRow("FILES", "file_id", "logical_file_name", plfn)
 		if err != nil {
 			msg := fmt.Sprintf("unable to find parent lfn %s", plfn)
-			return Error(err, DatabaseErrorCode, msg, "dbs.bulkblocks.InsertBulkBlocksConcurrently")
+			return Error(err, FileParentDoesNotExist, msg, "dbs.bulkblocks.InsertBulkBlocksConcurrently")
 		}
 		parentFilesMap[plfn] = pfid
 	}


### PR DESCRIPTION
Change error code from generic `DatabaseErrorCode ` to concrete `FileParentDoesNotExist` when we check parent file presence in database. 