### PR TITLE
Improve DBS errors output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 vet:
 	go vet .
 
-ORAFILES =  web/server.go test/merge/main.go test/seq/seq.go test/http_test.go test/writer_test.go
+ORAFILES =  web/server.go test/merge/main.go test/seq/seq.go test/http_test.go test/writer_test.go test/oracle_drivers_test.go test/seq/oracle_drivers_test.go test/merge/oracle_drivers_test.go cgotest/oracle_drivers.go
 
 strip_oracle:
 	$(info ### on $(arch) platform there is no ORALCE libs, we will disable their drivers from the build)
@@ -92,6 +92,7 @@ test-lexicon: test-lexicon-writer-pos test-lexicon-writer-neg test-lexicon-reade
 
 test-errors:
 	cd test && LD_LIBRARY_PATH=${odir} DYLD_LIBRARY_PATH=${odir} go test -v -run TestDBSError
+test-errors-no-oracle: strip_oracle test-errors restore_oracle
 test-dbs:
 	cd test && rm -f /tmp/dbs-test.db && \
 	sqlite3 /tmp/dbs-test.db < ../static/schema/sqlite-schema.sql && \

--- a/dbs/errors.go
+++ b/dbs/errors.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"strings"
 )
 
 // GenericErr represents generic dbs error
@@ -91,24 +90,16 @@ type DBSError struct {
 
 // Error function implements details of DBS error message
 func (e *DBSError) Error() string {
-	sep := ": "
-	if strings.Contains(e.Reason, "DBSError") { // nested error
-		sep += "nested "
-	}
 	return fmt.Sprintf(
-		"DBSError Code:%d Description:%s Function:%s Message:%s Error%s%v",
-		e.Code, e.Explain(), e.Function, e.Message, sep, e.Reason)
+		"\nDBSError\n   Code: %d\n   Description: %s\n   Function: %s\n   Message: %s\n   Reason: %v\n",
+		e.Code, e.Explain(), e.Function, e.Message, e.Reason)
 }
 
 // ErrorStacktrace function implements details of DBS error message and stacktrace
 func (e *DBSError) ErrorStacktrace() string {
-	sep := ": "
-	if strings.Contains(e.Reason, "DBSError") { // nested error
-		sep += "nested "
-	}
 	return fmt.Sprintf(
-		"DBSError Code:%d Description:%s Function:%s Message:%s Error%s%v Stacktrace: %v",
-		e.Code, e.Explain(), e.Function, e.Message, sep, e.Reason, e.Stacktrace)
+		"\nDBSError Stacktrace\n   Code: %d\n   Description: %s\n   Function: %s\n   Message: %s\n   Reason: %v\nStacktrace: %v\n\n",
+		e.Code, e.Explain(), e.Function, e.Message, e.Reason, e.Stacktrace)
 }
 
 func (e *DBSError) Explain() string {

--- a/test/errors_test.go
+++ b/test/errors_test.go
@@ -53,7 +53,7 @@ func TestDBSError(t *testing.T) {
 	fmt.Println("Wrapped error:", err3.Error())
 
 	err4 := dbs.Error(nil, dbs.GenericErrorCode, "nil wrapper", "TestDBSError")
-	if !strings.Contains(err4.Error(), "Error: nil") {
+	if !strings.Contains(err4.Error(), "nil") {
 		t.Error("error does not contain nil error")
 	}
 	fmt.Println("Wrapped error:", err4.Error())

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -266,6 +266,18 @@ func ErrorsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
+// TestErrorHandler provides basic functionality of status response
+func TestErrorHandler(w http.ResponseWriter, r *http.Request) {
+	err := dbs.Error(errors.New("original error"), dbs.GenericErrorCode, "test", "web.TestErrorHandler")
+	e := dbs.Error(err, dbs.LastAvailableErrorCode, "test", "web.TestErrorHandler")
+	if r.Header.Get("Accept") == "application/json" {
+		responseMsg(w, r, e, http.StatusInternalServerError)
+		return
+	}
+	http.Error(w, e.Error(), http.StatusInternalServerError)
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
 // StatusHandler provides basic functionality of status response
 func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	// we will use DBS DatasetAccessTypes API to check status of DBS

--- a/web/server.go
+++ b/web/server.go
@@ -153,6 +153,7 @@ func Handlers() *mux.Router {
 
 		router.HandleFunc(basePath("/dbstats"), DBStatsHandler).Methods("GET")
 		router.HandleFunc(basePath("/status"), StatusHandler).Methods("GET")
+		router.HandleFunc(basePath("/error"), TestErrorHandler).Methods("GET")
 
 		// load graphql
 		if Config.GraphQLSchema != "" {


### PR DESCRIPTION
Current DBS error representation is far from optimal and hard to comprehend and parse by upstream user or client. This PR provides necessary changes to simplify DBS error representation both within DBS logs and on a client side. 

Part of https://github.com/dmwm/WMCore/issues/12229

The proposed changes will have the following representations:

### Client side
On a client side we will see DBSError as following:

```
# plain html response
curl -kLs http://localhost:9898/dbs2go/error

DBSError
   Code: 141
   Description: Not defined
   Function: web.TestErrorHandler
   Message: test
   Reason:
DBSError
   Code: 100
   Description: Generic DBS error
   Function: web.TestErrorHandler
   Message: test
   Reason: original error
```

If client will request JSON output then DBS error JSON representation will still preserve DBSError order, from upper to lower and use newline separator between individual error attributes. For instance, `reason` attribute represents internal (original) error. The `code` represents upstream error code thrown by DBS server, the `message` contains nested error, and `http.code` represents HTTP server side error.
```
# JSON response
curl -kLs -H "Accept: application/json" http://localhost:9898/dbs2go/error | jq
[
  {
    "error": {
      "reason": "\nDBSError\n   Code: 100\n   Description: Generic DBS error\n   Function: web.TestErrorHandler\n   Message: test\n   Reason: original error\n",
      "message": "test",
      "function": "web.TestErrorHandler",
      "code": 141,
      "stacktrace": "\ngoroutine 66 [running]:\ngithub.com/dmwm/dbs2go/dbs.Error({0x102cb5300?, 0x140004de0f0?}, 0x8d, {0x102a7ed0b, 0x4}, {0x102a92d7a, 0x14})\n\t/Users/vk/Work/Languages/Go/gopath/src/github.com/dmwm/dbs2go/dbs/errors.go:176 +0x84\ngithub.com/dmwm/dbs2go/web.TestErrorHandler({0x102cb9290, 0x14000204090}, 0x140004da3c0)\n\t/Users/vk/Work/Languages/Go/gopath/src/github.com/dmwm/dbs2go/web/handlers.go:272 +0xb8\nnet/http.HandlerFunc.ServeHTTP(0x0?, {0x102cb9290?, 0x14000204090?}, 0x11?)\n\t/opt/local/lib/go/src/net/http/server.go:2294 +0x38\ngithub.com/dmwm/dbs2go/web.limitMiddleware.func1({0x102cb9290?, 0x14000204090?}, 0x14?)\n\t/Users/vk/Work/Languages/Go/gopath/src/github.com/dmwm/dbs2go/web/middlewares.go:110 +0x40\nnet/http.HandlerFunc.ServeHTTP(0x140004a8780?, {0x102cb9290?, 0x14000204090?}, 0x140002500c6?)\n\t/opt/local/lib/go/src/net/http/server.go:2294 +0x38\ngithub.com/dmwm/dbs2go/web.limitMiddleware.(*Middleware).Handler.func2({0x102cb9290, 0x14000204090}, 0x140004da3c0)\n\t/Users/vk/Work/Languages/Go/gopath/pkg/mod/github"
    },
    "http": {
      "method": "GET",
      "code": 500,
      "timestamp": "2025-03-12 14:02:42.834541 -0400 EDT m=+54.440451792",
      "path": "/dbs2go/error",
      "user_agent": "curl/8.12.1",
      "x_forwarded_host": "",
      "x_forwarded_for": "",
      "remote_addr": "[::1]:55724"
    },
    "exception": 500,
    "type": "HTTPError",
    "message": "\nDBSError\n   Code: 141\n   Description: Not defined\n   Function: web.TestErrorHandler\n   Message: test\n   Reason: \nDBSError\n   Code: 100\n   Description: Generic DBS error\n   Function: web.TestErrorHandler\n   Message: test\n   Reason: original error\n\n"
  }
]
```
Therefore, for upstream clients it should use `error.reason` part of JSON response which contains internal (original) code. Or, client may look at upstream error code and/or message to understand DBS error flow.

### Server side
On a server side the error will be reported properly in the following format
```
[2025-03-12 14:02:42.834575 -0400 EDT m=+54.440486084] handlers.go:89:
DBSError Stacktrace
   Code: 141
   Description: Not defined
   Function: web.TestErrorHandler
   Message: test
   Reason:
DBSError
   Code: 100
   Description: Generic DBS error
   Function: web.TestErrorHandler
   Message: test
   Reason: original error

Stacktrace:
goroutine 66 [running]:
github.com/dmwm/dbs2go/dbs.Error({0x102cb5300?, 0x140004de0f0?}, 0x8d, {0x102a7ed0b, 0x4}, {0x102a92d7a, 0x14})
        /Users/vk/Work/Languages/Go/gopath/src/github.com/dmwm/dbs2go/dbs/errors.go:176 +0x84
github.com/dmwm/dbs2go/web.TestErrorHandler({0x102cb9290, 0x14000204090}, 0x140004da3c0)
        /Users/vk/Work/Languages/Go/gopath/src/github.com/dmwm/dbs2go/web/handlers.go:272 +0xb8
net/http.HandlerFunc.ServeHTTP(0x0?, {0x102cb9290?, 0x14000204090?}, 0x11?)
        /opt/local/lib/go/src/net/http/server.go:2294 +0x38
github.com/dmwm/dbs2go/web.limitMiddleware.func1({0x102cb9290?, 0x14000204090?}, 0x14?)
        /Users/vk/Work/Languages/Go/gopath/src/github.com/dmwm/dbs2go/web/middlewares.go:110 +0x40
net/http.HandlerFunc.ServeHTTP(0x140004a8780?, {0x102cb9290?, 0x14000204090?}, 0x140002500c6?)
        /opt/local/lib/go/src/net/http/server.go:2294 +0x38
github.com/dmwm/dbs2go/web.limitMiddleware.(*Middleware).Handler.func2({0x102cb9290, 0x14000204090}, 0x140004da3c0)
        /Users/vk/Work/Languages/Go/gopath/pkg/mod/github
```
where the last DBSError represents the original error.

**NOTES:** I also kept separate commit for `Makefile` to make it work on `macOS/arm64` where there is no ORACLE libraries. With this change the `dbs2go` code can be compiled and tested on this architecture. The internal database in this case will be SQLite. For instance, to test the aforementioned error someone can use the following test:
```
make test-errors-no-oracle
### on arm platform there is no ORALCE libs, we will disable their drivers from the build
for f in web/server.go test/merge/main.go test/seq/seq.go test/http_test.go test/writer_test.go test/oracle_drivers_test.go test/seq/oracle_drivers_test.go test/merge/oracle_drivers_test.go cgotest/oracle_drivers.go; do \
                sed -i -e "s,_ \"github.com/mattn/go-oci8\",//_ \"github.com/mattn/go-oci8\",g" $f; \
                sed -i -e "s,_ \"gopkg.in/rana/ora.v4\",//_ \"gopkg.in/rana/ora.v4\",g" $f; \
                rm $f-e; \
        done
cd test && LD_LIBRARY_PATH="" DYLD_LIBRARY_PATH="" go test -v -run TestDBSError
=== RUN   TestDBSError
dbsErr is type of DBSError
err is wrapper around ErrorTest
Wrapped error:
DBSError
   Code: 107
   Description: DBS parser error, e.g. mailformed input parameter to the query
   Function: TestDBSError
   Message: wrapper
   Reason:
DBSError
   Code: 100
   Description: Generic DBS error
   Function: helper
   Message: message
   Reason: test


    errors_test.go:57: error does not contain nil error
Wrapped error:
DBSError
   Code: 100
   Description: Generic DBS error
   Function: TestDBSError
   Message: nil wrapper
   Reason: nil

--- FAIL: TestDBSError (0.00s)
FAIL
exit status 1
FAIL    github.com/dmwm/dbs2go/test     0.283s
make: [test-errors] Error 1 (ignored)
### on arm platform there is no ORALCE libs, we will restore them after the build
for f in web/server.go test/merge/main.go test/seq/seq.go test/http_test.go test/writer_test.go test/oracle_drivers_test.go test/seq/oracle_drivers_test.go test/merge/oracle_drivers_test.go cgotest/oracle_drivers.go; do \
                sed -i -e "s,//_ \"github.com/mattn/go-oci8\",_ \"github.com/mattn/go-oci8\",g" $f; \
                sed -i -e "s,//_ \"gopkg.in/rana/ora.v4\",_ \"gopkg.in/rana/ora.v4\",g" $f; \
                rm $f-e; \
        done
```