### PR TITLE
Add /errors end-point to provide list of DBS error codes and their explanations

### DIFF
--- a/dbs/errors.go
+++ b/dbs/errors.go
@@ -388,3 +388,16 @@ func Error(err error, code int, msg, function string) error {
 		Stacktrace: fmt.Sprintf("\n%s", stackSlice[0:s]),
 	}
 }
+
+// GetDBSErrors returns map of DBS errors
+func GetDBSErrors() map[int]string {
+	errors := make(map[int]string)
+	for i := GenericErrorCode; i < LastAvailableErrorCode; i++ {
+		err := &DBSError{Code: i}
+		explain := err.Explain()
+		if explain != "Not defined" {
+			errors[i] = explain
+		}
+	}
+	return errors
+}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -256,7 +256,22 @@ func ErrorsHandler(w http.ResponseWriter, r *http.Request) {
 		errors = append(errors, e)
 	}
 
-	// marhsal the data to return back to caller
+	// marshal data to return back to caller
+	data, err := json.Marshal(errors)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+}
+
+// DBSErrorsHandler provides basic functionality of status response
+func DBSErrorsHandler(w http.ResponseWriter, r *http.Request) {
+	errors := dbs.GetDBSErrors()
+	// note: even though we define errors as map[int]string the json.Marshal
+	// will return dict of keys:values where keys are string. This is because
+	// JSON spec defines: an object is a collection of name/value pairs where the names are strings.
 	data, err := json.Marshal(errors)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/web/server.go
+++ b/web/server.go
@@ -153,6 +153,7 @@ func Handlers() *mux.Router {
 
 		router.HandleFunc(basePath("/dbstats"), DBStatsHandler).Methods("GET")
 		router.HandleFunc(basePath("/status"), StatusHandler).Methods("GET")
+		router.HandleFunc(basePath("/errors"), DBSErrorsHandler).Methods("GET")
 		router.HandleFunc(basePath("/error"), TestErrorHandler).Methods("GET")
 
 		// load graphql


### PR DESCRIPTION
The new `/errors` end point provide full list of DBS errors in the following format:
```
[
   {"code": 123, "meaning": <string>},
   {"code": 456, "meaning": <string>},
...
]
```