### PR TITLE
Adjust GetHash to allow shorten the hash of concurrent request

### DIFF
--- a/dbs/bulkblocks.go
+++ b/dbs/bulkblocks.go
@@ -164,7 +164,7 @@ func (a *API) InsertBulkBlocks() error {
 		return Error(err, ReaderErrorCode, msg, "dbs.bulkblocks.InsertBulkBlocks")
 	}
 	// get our request hash ID to be able to trace concurrent requests
-	hash := utils.GetHash(data)
+	hash := utils.GetHash(data, ConcurrentHashSize)
 
 	// unmarshal the data into BulkBlocks record
 	var rec BulkBlocks

--- a/dbs/bulkblocks2.go
+++ b/dbs/bulkblocks2.go
@@ -484,7 +484,7 @@ func (a *API) InsertBulkBlocksConcurrently() error {
 		return Error(err, ReaderErrorCode, msg, "dbs.bulkblocks.InsertBulkBlocksConcurrently")
 	}
 	// get our request hash ID to be able to trace concurrent requests
-	hash := utils.GetHash(data)
+	hash := fmt.Sprintf("request %s", utils.GetHash(data, ConcurrentHashSize))
 
 	if utils.VERBOSE > 1 {
 		log.Println(hash, "start bulkblocks.InsertBulkBlocksConcurrently")

--- a/dbs/dbs.go
+++ b/dbs/dbs.go
@@ -78,6 +78,9 @@ var FileLumiInsertMethod string
 // ConcurrentBulkBlocks defines if code should use concurrent bulkblocks API
 var ConcurrentBulkBlocks bool
 
+// ConcurrentHashSize defines size of hash to use to encode concurrent requests
+var ConcurrentHashSize int
+
 // DBRecord interface represents general DB record used by DBS APIs.
 // Each DBS API represents specific Table in back-end DB. And, each individual
 // DBS API implements logic for its own DB records

--- a/dbs/migrate.go
+++ b/dbs/migrate.go
@@ -249,7 +249,7 @@ func blocksInDB(blocks []string) ([]string, error) {
 		return blocks, nil
 	}
 	srcBlocks := []string{}
-	hash := utils.GetHash([]byte(blocks[0]))
+	hash := utils.GetHash([]byte(blocks[0]), ConcurrentHashSize)
 	tx, err := DB.Begin()
 	if err != nil {
 		return srcBlocks, Error(err, TransactionErrorCode, hash, "dbs.migrate.blocksInDB")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -331,7 +331,10 @@ func UpdateOrderedDict(omap, nmap map[int][]string) map[int][]string {
 }
 
 // GetHash generates SHA256 hash for given data blob
-func GetHash(data []byte) string {
+func GetHash(data []byte, size int) string {
 	hash := sha256.Sum256(data)
-	return hex.EncodeToString(hash[:])
+	if size == 0 {
+		return hex.EncodeToString(hash[:])
+	}
+	return hex.EncodeToString(hash[:size])
 }

--- a/web/config.go
+++ b/web/config.go
@@ -54,6 +54,7 @@ type Configuration struct {
 	FileLumiMaxSize      int    `json:"file_lumi_max_size"`      // max size for []FileLumi insertion
 	FileLumiInsertMethod string `json:"file_lumi_insert_method"` // insert method for FileLumi list
 	ConcurrentBulkBlocks bool   `json:"concurrent_bulkblocks"`   // use concurrent BulkBlocks API
+	ConcurrentHashSize   int    `json:"concurrent_hash_size"`    // size of hash to use to encode concurrent request
 
 	// server static parts
 	Templates string `json:"templates"` // location of server templates

--- a/web/server.go
+++ b/web/server.go
@@ -432,6 +432,7 @@ func Server(configFile string) {
 
 	// DBS bulkblocks API
 	dbs.ConcurrentBulkBlocks = Config.ConcurrentBulkBlocks
+	dbs.ConcurrentHashSize = Config.ConcurrentHashSize
 
 	// init graphql
 	if Config.GraphQLSchema != "" {


### PR DESCRIPTION
The current `GetHash` function provides 32 bit hash. Even though it is unique the produced unique string is very long (64 characters) and not human friendly. I provided configuration for size of the hash which we can use in DBS server. Here is examples of hashes of different size:
```
hash d384b98e6d31f62a6c05bcb5f3d3410b7b374f963df9cab179813b5e51c5bd1e
hash4 d384b98e
hash8 d384b98e6d31f62a
hash16 d384b98e6d31f62a6c05bcb5f3d3410b
hash32 d384b98e6d31f62a6c05bcb5f3d3410b7b374f963df9cab179813b5e51c5bd1e
```
Therefore, similar to github hashes in its log of commits we can use shorter hash in DBS logs/DBS error messages to point to particular concurrent request.

An example of actual DBSError with such has is the following:
```
>>> print(doc[0]['error']['message'])
04563cfae6aab9a565c9cdcc6bf65235591193a9b335ea2c368d964ffaae7c21 unable to find dataset_id for /unittest_web_primary_ds_name_60164_stepchain/acq_era_60164-pstr-v170/GEN-SIM-RAW
...
```
This DBS error provides the full hash which I find too long. This PR deal with this and provide flexibility how to handle it, along with adding additional `request <hash>`. 

**Note:** hashes are very useful to trace down particular log entries of concurrent request once someone get DBS error and need further debugging.