### PR TITLE
Add SetConnMaxLifetime DB pool option and default its value to 1h

### DIFF
--- a/web/config.go
+++ b/web/config.go
@@ -46,7 +46,8 @@ type Configuration struct {
 	DBFile               string `json:"dbfile"`                  // dbs db file with secrets
 	MaxDBConnections     int    `json:"max_db_connections"`      // maximum number of DB connections
 	MaxIdleConnections   int    `json:"max_idle_connections"`    // maximum number of idle connections
-	SetConnMaxLifetime   int    `json:"setConnMaxLifetime"`      // set max lifetime of DB connection
+	SetConnMaxLifetime   int    `json:"setConnMaxLifetime"`      // set max lifetime of DB connection in seconds
+	SetConnMaxIdleTime   int    `json:"setConnMaxIdleTime"`      // set max idle time of DB connection in seconds
 	DBMonitoringInterval int    `json:"db_monitoring_interval"`  // db mon interval in seconds
 	ApiParametersFile    string `json:"api_parameters_file"`     // api parameters json file
 	LexiconFile          string `json:"lexicon_file"`            // lexicon json file
@@ -105,9 +106,6 @@ func ParseConfig(configFile string) error {
 	}
 	if Config.MaxIdleConnections == 0 {
 		Config.MaxIdleConnections = 100
-	}
-	if Config.SetConnMaxLifetime == 0 {
-		Config.SetConnMaxLifetime = 3600 // in seconds
 	}
 	if Config.LimiterPeriod == "" {
 		Config.LimiterPeriod = "100-S"

--- a/web/config.go
+++ b/web/config.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	DBFile               string `json:"dbfile"`                  // dbs db file with secrets
 	MaxDBConnections     int    `json:"max_db_connections"`      // maximum number of DB connections
 	MaxIdleConnections   int    `json:"max_idle_connections"`    // maximum number of idle connections
+	SetConnMaxLifetime   int    `json:"setConnMaxLifetime"`      // set max lifetime of DB connection
 	DBMonitoringInterval int    `json:"db_monitoring_interval"`  // db mon interval in seconds
 	ApiParametersFile    string `json:"api_parameters_file"`     // api parameters json file
 	LexiconFile          string `json:"lexicon_file"`            // lexicon json file
@@ -104,6 +105,9 @@ func ParseConfig(configFile string) error {
 	}
 	if Config.MaxIdleConnections == 0 {
 		Config.MaxIdleConnections = 100
+	}
+	if Config.SetConnMaxLifetime == 0 {
+		Config.SetConnMaxLifetime = 3600 // in seconds
 	}
 	if Config.LimiterPeriod == "" {
 		Config.LimiterPeriod = "100-S"

--- a/web/server.go
+++ b/web/server.go
@@ -266,6 +266,7 @@ func dbInit(dbtype, dburi string) (*sql.DB, error) {
 	}
 	db.SetMaxOpenConns(Config.MaxDBConnections)
 	db.SetMaxIdleConns(Config.MaxIdleConnections)
+	db.SetConnMaxLifetime(Config.SetConnMaxLifetime * Time.Second)
 	// Disables connection pool for sqlite3. This enables some concurrency with sqlite3 databases
 	// See https://stackoverflow.com/questions/57683132/turning-off-connection-pool-for-go-http-client
 	// and https://sqlite.org/wal.html

--- a/web/server.go
+++ b/web/server.go
@@ -266,7 +266,12 @@ func dbInit(dbtype, dburi string) (*sql.DB, error) {
 	}
 	db.SetMaxOpenConns(Config.MaxDBConnections)
 	db.SetMaxIdleConns(Config.MaxIdleConnections)
-	db.SetConnMaxLifetime(Config.SetConnMaxLifetime * Time.Second)
+	if Config.SetConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(time.Duration(Config.SetConnMaxLifetime) * time.Second)
+	}
+	if Config.SetConnMaxIdleTime > 0 {
+		db.SetConnMaxIdleTime(time.Duration(Config.SetConnMaxIdleTime) * time.Second)
+	}
 	// Disables connection pool for sqlite3. This enables some concurrency with sqlite3 databases
 	// See https://stackoverflow.com/questions/57683132/turning-off-connection-pool-for-go-http-client
 	// and https://sqlite.org/wal.html


### PR DESCRIPTION
In production agents we observed failureWorkflowUpdater WM component due to `ORA-02391: exceeded simultaneous SESSIONS_PER_USER limit`, see [gist](https://gist.github.com/vkuznet/f42a31fcb3d3e349f6abcedf3db076ad). This PR provides additional dbs2go configuration option to set maximum lifetime of DB connection via `SetConnMaxLifetime` option.