### PR TITLE
Add make actions to replicate CI/CD functionalities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,26 +32,62 @@ TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || git describe --t
 REPO_FALLBACK ?= dmwm/dbs2go
 REPO_URL ?= $(shell git remote get-url upstream 2>/dev/null || git remote get-url origin 2>/dev/null || echo https://github.com/$(REPO_FALLBACK).git)
 REPO ?= $(shell echo $(REPO_URL) | sed -e 's,.*github.com[:/],,' -e 's,.git$$,,')
-IMAGE ?= registry.cern.ch/cmsweb/dbs2go
+REGISTRY ?= registry.cern.ch
+PROJECT ?= cmsweb
+REPOSITORY ?= dbs2go
+IMAGE ?= $(REGISTRY)/$(PROJECT)/$(REPOSITORY)
 IMAGEBOT_NAMESPACE ?= dbs
 IMAGEBOT_SERVICE ?= dbs2go
 UPLOAD_BUILD_TARGET ?= build
+DOCKER_ACTION := $(word 2,$(MAKECMDGOALS))
+DOCKER_REF := $(word 3,$(MAKECMDGOALS))
+DOCKER_TAG_ARG := $(if $(DOCKER_REF),TAG=$(DOCKER_REF),)
 
-ifneq (,$(filter upload k8deploy,$(firstword $(MAKECMDGOALS))))
+ifneq (,$(filter upload docker k8deploy,$(firstword $(MAKECMDGOALS))))
   ifeq (no-oracle,$(word 2,$(MAKECMDGOALS)))
     UPLOAD_BUILD_TARGET := build-no-oracle
     $(eval no-oracle:;@true)
   endif
 endif
 
-.PHONY: upload upload-no-oracle k8deploy k8deploy-no-oracle
-upload: $(UPLOAD_BUILD_TARGET)
+.PHONY: upload upload-no-oracle docker docker-build docker-push push k8deploy k8deploy-no-oracle
+upload:
+	$(MAKE) docker-build UPLOAD_BUILD_TARGET=$(UPLOAD_BUILD_TARGET)
+	$(MAKE) docker-push
+
+docker:
+	@case "$(DOCKER_ACTION)" in \
+		build) $(MAKE) docker-build $(DOCKER_TAG_ARG) ;; \
+		push) $(MAKE) docker-push $(DOCKER_TAG_ARG) ;; \
+		*) echo "Usage: make docker {build|push} [<tag-or-commit>]"; exit 1 ;; \
+	esac
+
+# The second word in `make docker build` or `make docker push` is also parsed
+# by make as a goal. These targets prevent it from running a second action.
+ifeq (docker,$(firstword $(MAKECMDGOALS)))
+push:
+	@true
+%:
+	@true
+endif
+
+docker-build:
 	@set -e; \
 	case "$(TAG)" in \
-		v*.*.*rc*) stable="false" ;; \
-		v*.*.*|*.*.*) stable="true" ;; \
-		*) echo "TAG=$(TAG) is not a release or rc tag"; exit 1 ;; \
+		v*.*.*rc*|v*.*.*|*.*.*) ;; \
+		*) \
+			echo "$(TAG)" | grep -Eq '^[[:xdigit:]]{7,40}$$' || { \
+				echo "TAG=$(TAG) is not a release tag or commit ID"; exit 1; \
+			}; \
+			commit=$$(git rev-parse --verify "$(TAG)^{commit}" 2>/dev/null) || { \
+				echo "Commit $(TAG) does not exist locally"; exit 1; \
+			}; \
+			head=$$(git rev-parse HEAD); \
+			[ "$$commit" = "$$head" ] || { \
+				echo "Commit $(TAG) is not currently checked out (HEAD=$$head)"; exit 1; \
+			} ;; \
 	esac; \
+	$(MAKE) $(UPLOAD_BUILD_TARGET); \
 	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/Dockerfile; \
 	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/oci8.pc; \
 	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/config.json; \
@@ -60,6 +96,20 @@ upload: $(UPLOAD_BUILD_TARGET)
 	chmod +x run.sh; \
 	sed -i -e "s,ENV TAG=.*,ENV TAG=$(TAG),g" Dockerfile; \
 	docker build . --tag "$(IMAGE):$(TAG)"; \
+	docker image inspect "$(IMAGE):$(TAG)" >/dev/null
+
+docker-push:
+	@set -e; \
+	case "$(TAG)" in \
+		v*.*.*rc*) stable="false" ;; \
+		v*.*.*|*.*.*) stable="true" ;; \
+		*) echo "TAG=$(TAG) is not a release or rc tag"; exit 1 ;; \
+	esac; \
+	docker image inspect "$(IMAGE):$(TAG)" >/dev/null || { \
+		echo "Docker image $(IMAGE):$(TAG) does not exist locally; run 'make docker build TAG=$(TAG)' first"; \
+		exit 1; \
+	}; \
+	docker login "$(REGISTRY)"; \
 	docker push "$(IMAGE):$(TAG)"; \
 	if [ "$$stable" = "true" ]; then \
 		docker tag "$(IMAGE):$(TAG)" "$(IMAGE):$(TAG)-stable"; \
@@ -108,10 +158,15 @@ restore_oracle: $(ORAFILES)
 		rm $$f-e; \
 	done
 
+ifeq (docker,$(firstword $(MAKECMDGOALS)))
+build:
+	@true
+else
 build:
 	$(info ### building dbs2go executable on $(arch))
 	go clean; rm -rf pkg dbs2go*; go build ${flags}
 	@echo
+endif
 
 .IGNORE:
 build_no_oracle: strip_oracle build restore_oracle

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,69 @@ endif
 release: ./buildRelease.sh
 	./buildRelease.sh -t $(RELEASE)
 
+TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags)
+REPO_FALLBACK ?= dmwm/dbs2go
+REPO_URL ?= $(shell git remote get-url upstream 2>/dev/null || git remote get-url origin 2>/dev/null || echo https://github.com/$(REPO_FALLBACK).git)
+REPO ?= $(shell echo $(REPO_URL) | sed -e 's,.*github.com[:/],,' -e 's,.git$$,,')
+IMAGE ?= registry.cern.ch/cmsweb/dbs2go
+IMAGEBOT_NAMESPACE ?= dbs
+IMAGEBOT_SERVICE ?= dbs2go
+UPLOAD_BUILD_TARGET ?= build
+
+ifneq (,$(filter upload k8deploy,$(firstword $(MAKECMDGOALS))))
+  ifeq (no-oracle,$(word 2,$(MAKECMDGOALS)))
+    UPLOAD_BUILD_TARGET := build-no-oracle
+    $(eval no-oracle:;@true)
+  endif
+endif
+
+.PHONY: upload upload-no-oracle k8deploy k8deploy-no-oracle
+upload: $(UPLOAD_BUILD_TARGET)
+	@set -e; \
+	case "$(TAG)" in \
+		v*.*.*rc*) stable="false" ;; \
+		v*.*.*|*.*.*) stable="true" ;; \
+		*) echo "TAG=$(TAG) is not a release or rc tag"; exit 1 ;; \
+	esac; \
+	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/Dockerfile; \
+	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/oci8.pc; \
+	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/config.json; \
+	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/monitor.sh; \
+	curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/dbs2go/run.sh; \
+	chmod +x run.sh; \
+	sed -i -e "s,ENV TAG=.*,ENV TAG=$(TAG),g" Dockerfile; \
+	docker build . --tag "$(IMAGE):$(TAG)"; \
+	docker push "$(IMAGE):$(TAG)"; \
+	if [ "$$stable" = "true" ]; then \
+		docker tag "$(IMAGE):$(TAG)" "$(IMAGE):$(TAG)-stable"; \
+		docker push "$(IMAGE):$(TAG)-stable"; \
+	fi
+
+upload-no-oracle:
+	$(MAKE) upload no-oracle
+
+k8deploy:
+	@set -e; \
+	[ -n "$${IMAGEBOT_URL}" ] || { echo "ERROR: IMAGEBOT_URL is not set"; exit 1; }; \
+	curl -ksLO https://raw.githubusercontent.com/vkuznet/imagebot/main/imagebot.sh; \
+	sed -i -e "s,COMMIT,$$(git rev-parse HEAD),g" \
+		-e "s,REPOSITORY,$(REPO),g" \
+		-e "s,NAMESPACE,$(IMAGEBOT_NAMESPACE),g" \
+		-e "s,TAG,$(TAG),g" \
+		-e "s,IMAGE,$(IMAGE),g" \
+		-e "s,SERVICE,$(IMAGEBOT_SERVICE),g" \
+		-e "s,HOST,$${IMAGEBOT_URL},g" imagebot.sh; \
+	chmod +x imagebot.sh; \
+	sh ./imagebot.sh
+
+k8deploy-no-oracle: k8deploy
+
+
 vet:
 	go vet .
 
-ORAFILES =  web/server.go test/merge/main.go test/seq/seq.go test/http_test.go test/writer_test.go test/oracle_drivers_test.go test/seq/oracle_drivers_test.go test/merge/oracle_drivers_test.go cgotest/oracle_drivers.go
+ORAFILES_ALL = web/server.go test/merge/main.go test/seq/seq.go test/http_test.go test/writer_test.go test/oracle_drivers_test.go test/seq/oracle_drivers_test.go test/merge/oracle_drivers_test.go cgotest/oracle_drivers.go
+ORAFILES = $(wildcard $(ORAFILES_ALL))
 
 strip_oracle:
 	$(info ### on $(arch) platform there is no ORALCE libs, we will disable their drivers from the build)
@@ -56,6 +115,8 @@ build:
 
 .IGNORE:
 build_no_oracle: strip_oracle build restore_oracle
+
+build-no-oracle: build_no_oracle
 
 build_debug:
 	go clean; rm -rf pkg dbs2go*; go build -gcflags=all="-N -l" ${debug_flags}

--- a/README.md
+++ b/README.md
@@ -21,3 +21,40 @@ documentation:
 - [DBS APIs](docs/apis.md)
 - [Debugging and Profiling DBS server](docs/Debug.md)
 - [DBS GraphQL](graphql/README.md)
+
+#### Release, upload, and k8s deployment
+
+The release flow can be executed manually in three steps:
+
+```
+make release v1.2.3
+make upload TAG=v1.2.3
+make k8deploy TAG=v1.2.3 IMAGEBOT_URL=<imagebot-url>
+```
+
+`make release <tag>` calls `buildRelease.sh`, updates the changelog, creates
+the release commit and tag, and pushes them to the configured git remote.
+
+`make upload` builds the local `dbs2go` binary with Oracle support enabled by
+default, builds the Docker image, and pushes it to
+`registry.cern.ch/cmsweb/dbs2go`. Stable release tags also push a
+`<tag>-stable` image tag.
+
+`make k8deploy` runs the imagebot deployment step. The repository passed to
+imagebot is resolved from the `upstream` git remote, then `origin`, and finally
+falls back to `dmwm/dbs2go`. It can be overridden with `REPO=<owner>/<repo>`.
+
+For builds without Oracle drivers, use either form:
+
+```
+make upload no-oracle TAG=v1.2.3
+make upload-no-oracle TAG=v1.2.3
+```
+
+The k8s deployment target accepts the same suffix for command consistency,
+although it does not build anything after the upload/deploy split:
+
+```
+make k8deploy no-oracle TAG=v1.2.3 IMAGEBOT_URL=<imagebot-url>
+make k8deploy-no-oracle TAG=v1.2.3 IMAGEBOT_URL=<imagebot-url>
+```

--- a/README.md
+++ b/README.md
@@ -28,17 +28,33 @@ The release flow can be executed manually in three steps:
 
 ```
 make release v1.2.3
-make upload TAG=v1.2.3
+make docker build v1.2.3
+make docker push v1.2.3
 make k8deploy TAG=v1.2.3 IMAGEBOT_URL=<imagebot-url>
 ```
 
 `make release <tag>` calls `buildRelease.sh`, updates the changelog, creates
 the release commit and tag, and pushes them to the configured git remote.
 
-`make upload` builds the local `dbs2go` binary with Oracle support enabled by
-default, builds the Docker image, and pushes it to
-`registry.cern.ch/cmsweb/dbs2go`. Stable release tags also push a
-`<tag>-stable` image tag.
+`make docker build` builds the local `dbs2go` binary with Oracle support
+enabled by default, builds the Docker image, and verifies that the tagged image
+exists locally. `make docker push` verifies the image, logs in to the configured
+registry, and pushes it to `registry.cern.ch/cmsweb/dbs2go`. Stable release
+tags also push a `<tag>-stable` image tag. The existing
+`make upload TAG=<tag>` command remains
+available as a wrapper that performs both actions in sequence. The image URL is
+assembled from `REGISTRY=registry.cern.ch`, `PROJECT=cmsweb`, and
+`REPOSITORY=dbs2go`; each component can be overridden on the make command line.
+
+The Docker build also accepts the hexadecimal ID of the currently checked-out
+local commit:
+
+```
+make docker build <commit-id>
+```
+
+The commit must exist locally and resolve to `HEAD`; the build does not change
+the working tree or check out a different revision.
 
 `make k8deploy` runs the imagebot deployment step. The repository passed to
 imagebot is resolved from the `upstream` git remote, then `origin`, and finally


### PR DESCRIPTION
## Summary

Implements the manual Makefile-driven release flow requested in #153.

This PR adds explicit Make targets for maintainer-controlled image publication and deployment actions that were previously only described in GitHub Actions, including:

- image upload/publication to `registry.cern.ch/cmsweb/dbs2go`;
- stable tag handling for final releases;
- no-Oracle image upload variants;
- imagebot-based k8s deployment updates;
- README documentation for the manual release/upload/deploy procedure.

The intended release flow becomes explicit and locally controlled:

    git tag <release-tag>
    make upload TAG=<release-tag>
    make k8deploy TAG=<release-tag> IMAGEBOT_URL=<imagebot-url>

This addresses the Makefile-side requirements from #153 by making the privileged release operations manually executable through `make`.

Closes #153.